### PR TITLE
Footer items fix and updates the year to 2023

### DIFF
--- a/parts/footer.html
+++ b/parts/footer.html
@@ -33,15 +33,15 @@
     <!-- /wp:group -->
     
     <!-- wp:group {"style":{"spacing":{"padding":{"top":"24px","bottom":"24px","right":"24px","left":"24px"},"margin":{"top":"0px","bottom":"0px"}}},"backgroundColor":"ti-bg-inv","textColor":"ti-fg-alt","className":"has-ti-fg-background-color","layout":{"inherit":true,"type":"constrained"}} -->
-    <div class="wp-block-group has-ti-fg-background-color has-ti-fg-alt-color has-ti-bg-inv-background-color has-text-color has-background" style="margin-top:0px;margin-bottom:0px;padding-top:24px;padding-right:24px;padding-bottom:24px;padding-left:24px"><!-- wp:group {"className":"alignwide","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+    <div class="wp-block-group has-ti-fg-background-color has-ti-fg-alt-color has-ti-bg-inv-background-color has-text-color has-background" style="margin-top:0px;margin-bottom:0px;padding-top:24px;padding-right:24px;padding-bottom:24px;padding-left:24px"><!-- wp:group {"className":"alignwide","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
     <div class="wp-block-group alignwide"><!-- wp:group {"layout":{"type":"flex"}} -->
     <div class="wp-block-group"><!-- wp:paragraph {"style":{"spacing":{"margin":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}},"fontSize":"small"} -->
-    <p class="has-small-font-size" style="margin-top:0px;margin-right:0px;margin-bottom:0px;margin-left:0px">Copyright 2022 - Website</p>
+    <p class="has-small-font-size" style="margin-top:0px;margin-right:0px;margin-bottom:0px;margin-left:0px">Copyright 2023 - Riverbank FSE theme</p>
     <!-- /wp:paragraph --></div>
     <!-- /wp:group -->
     
     <!-- wp:group {"layout":{"type":"flex"}} -->
-    <div class="wp-block-group"><!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right","flexWrap":"nowrap"},"style":{"spacing":{"blockGap":"32px"}},"fontSize":"small"} -->
+    <div class="wp-block-group"><!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"space-between","flexWrap":"wrap"},"style":{"spacing":{"blockGap":"32px"}},"fontSize":"small"} -->
     <!-- wp:navigation-link {"label":"Privacy Policy","url":"#","kind":"custom","isTopLevelLink":true} /-->
     <!-- /wp:navigation --></div>
     <!-- /wp:group --></div>


### PR DESCRIPTION


### Summary
<!-- Please describe the changes you made. -->
Improved the issue mentioned [here](https://github.com/Codeinwp/riverbank/issues/23).
**But long term, we'll need to change this when Core has new updates.**

Basically the issue is that Flex items that are Row on Desktop, will remain Row on Mobile also - ideally it should be possible to change the behaviour on Mobile. Hopefully Core will address this in future.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES


### Screenshots 
<!-- if applicable -->

![Screenshot 2023-04-28 at 18 15 36](https://user-images.githubusercontent.com/52494172/235186740-0f0291cf-b570-4d84-8a3a-8ba8d68fd431.png)


### Test instructions
<!-- Describe how this pull request can be tested. -->

- Create a fresh instance with Riverbank
- Add multiple items in the Footer menu
- Check that on Mobile, those don't looked so cramped as before (previous version)

<!-- Issues that this pull request closes. -->
Closes #23 .
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->