### PR TITLE
fix: make navigation block responsive

### DIFF
--- a/assets/css/src/blocks/_navigation.scss
+++ b/assets/css/src/blocks/_navigation.scss
@@ -24,4 +24,40 @@
 	.wp-block-navigation__submenu-container {
 		gap: 24px !important;
 	}
+
+	.wp-block-navigation__responsive-container-content {
+
+		.wp-block-navigation-item {
+			display: flex;
+			justify-content: space-between;
+			flex-direction: row;
+			flex-wrap: wrap;
+			align-items: center;
+			padding: 0 24px;
+			width: 100vw;
+		}
+
+		.has-child {
+
+			.wp-block-navigation__submenu-container {
+				display: none;
+			}
+
+			&:hover {
+
+				.wp-block-navigation__submenu-container {
+					display: block;
+					width: 100%;
+					padding: 0;
+					padding-top: var(--wp--style--block-gap, 2em);
+				}
+			}
+		}
+
+		.wp-block-navigation__submenu-icon {
+			display: inline-block;
+			cursor: pointer;
+		}
+	}
+
 }

--- a/assets/css/src/blocks/_navigation.scss
+++ b/assets/css/src/blocks/_navigation.scss
@@ -36,28 +36,22 @@
 			padding: 0 24px;
 			width: 100vw;
 			box-sizing: border-box;
-		}
-
-		.has-child {
 
 			.wp-block-navigation__submenu-container {
 				display: none;
 			}
 
-			&:hover {
-
-				.wp-block-navigation__submenu-container {
-					display: block;
-					width: 100%;
-					padding: 0;
-					padding-top: var(--wp--style--block-gap, 2em);
-				}
+			.wp-block-navigation__submenu-icon {
+				display: inline-block;
+				cursor: pointer;
 			}
-		}
 
-		.wp-block-navigation__submenu-icon {
-			display: inline-block;
-			cursor: pointer;
+			&.is-submenu-open > .wp-block-navigation__submenu-container {
+				display: block;
+				width: 100%;
+				padding: 0;
+				padding-top: var(--wp--style--block-gap, 2em);
+			}
 		}
 	}
 

--- a/assets/css/src/blocks/_navigation.scss
+++ b/assets/css/src/blocks/_navigation.scss
@@ -35,6 +35,7 @@
 			align-items: center;
 			padding: 0 24px;
 			width: 100vw;
+			box-sizing: border-box;
 		}
 
 		.has-child {

--- a/assets/js/src/script.js
+++ b/assets/js/src/script.js
@@ -1,0 +1,7 @@
+/* global jQuery */
+
+jQuery( document ).ready( ( $ ) => {
+	$( '.wp-block-navigation-submenu__toggle' ).on( 'click', function () {
+		$( this ).parent( 'li' ).toggleClass( 'is-submenu-open' );
+	} );
+} );

--- a/inc/Assets_Manager.php
+++ b/inc/Assets_Manager.php
@@ -20,6 +20,7 @@ class Assets_Manager {
 		'editor-css'         => 'riverbank-editor',
 		'welcome-notice'     => 'riverbank-welcome-notice',
 		'design-pack-notice' => 'riverbank-design-pack-notice',
+		'frontend-js'        => 'riverbank-script',
 	);
 
 	/**

--- a/inc/Core.php
+++ b/inc/Core.php
@@ -97,6 +97,7 @@ class Core {
 	 */
 	public function enqueue() {
 		Assets_Manager::enqueue_style( Assets_Manager::ASSETS_SLUGS['frontend-css'], 'style' );
+		Assets_Manager::enqueue_script( Assets_Manager::ASSETS_SLUGS['frontend-js'], 'script', true, array( 'jquery' ) );
 	}
 
 	/**


### PR DESCRIPTION
### Summary
Override the default navigation block CSS to make it responsive.

### Screenshots
<img width="391" height="656" alt="image" src="https://github.com/user-attachments/assets/ed6a76b6-4363-44ff-9c28-00f03da575e2" />

Closes https://github.com/Codeinwp/riverbank/issues/105